### PR TITLE
Remove header sec-websocket-extensions (fixes handshaking)

### DIFF
--- a/websocket.go
+++ b/websocket.go
@@ -13,18 +13,20 @@ import (
 )
 
 var (
-	ConnectionHeaderKey = http.CanonicalHeaderKey("connection")
-	SetCookieHeaderKey  = http.CanonicalHeaderKey("set-cookie")
-	UpgradeHeaderKey    = http.CanonicalHeaderKey("upgrade")
-	WSKeyHeaderKey      = http.CanonicalHeaderKey("sec-websocket-key")
-	WSProtocolHeaderKey = http.CanonicalHeaderKey("sec-websocket-protocol")
-	WSVersionHeaderKey  = http.CanonicalHeaderKey("sec-websocket-version")
+	ConnectionHeaderKey   = http.CanonicalHeaderKey("connection")
+	SetCookieHeaderKey    = http.CanonicalHeaderKey("set-cookie")
+	UpgradeHeaderKey      = http.CanonicalHeaderKey("upgrade")
+	WSKeyHeaderKey        = http.CanonicalHeaderKey("sec-websocket-key")
+	WSProtocolHeaderKey   = http.CanonicalHeaderKey("sec-websocket-protocol")
+	WSVersionHeaderKey    = http.CanonicalHeaderKey("sec-websocket-version")
+	WSExtensionsHeaderKey = http.CanonicalHeaderKey("sec-websocket-extensions")
 
 	ConnectionHeaderValue = "Upgrade"
 	UpgradeHeaderValue    = "websocket"
 
-	HandshakeHeaders = []string{ConnectionHeaderKey, UpgradeHeaderKey, WSVersionHeaderKey, WSKeyHeaderKey}
-	UpgradeHeaders   = []string{SetCookieHeaderKey, WSProtocolHeaderKey}
+	HandshakeHeaders = []string{ConnectionHeaderKey, UpgradeHeaderKey, WSVersionHeaderKey,
+		WSKeyHeaderKey, WSExtensionsHeaderKey}
+	UpgradeHeaders = []string{SetCookieHeaderKey, WSProtocolHeaderKey}
 )
 
 func (u *UpstreamProxy) handleWebsocket(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Got a lot of these
`dialing upstream websocket failed: websocket: duplicate header not allowed: Sec-Websocket-Extensions`
in my logs and websockets were failing.

This header is used for websocket handshaking and should also be removed from requests to upstream.